### PR TITLE
inflate64 1.0.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 {% set version = "1.0.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/inflate64-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b398c686960c029777afc0ed281a86f66adb956cfc3fbf6667cc6453f7b407ce
 
 build:
@@ -23,10 +23,14 @@ requirements:
     - python
     - setuptools >=45
     - setuptools-scm >=6.0.1
+    - wheel
     - toml
   run:
     - python
   run_constrained:
+    # docs
+    - sphinx >=5.0
+    # check
     - mypy >=1.10.0
     - mypy_extensions >=0.4.1
 
@@ -38,7 +42,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests
+    - pytest -vv tests
   requires:
     - pip
     - pytest
@@ -50,8 +54,8 @@ about:
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: COPYING
-  dev_url: https://codeberg.org/miurahr/inflate64
-  doc_url: https://inflate64.readthedocs.io
+  dev_url: https://github.com/miurahr/inflate64/
+  doc_url: https://inflate64.readthedocs.io/en/latest
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "inflate64" %}
-{% set version = "1.0.3" %}
+{% set version = "1.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/inflate64-{{ version }}.tar.gz
-  sha256: a89edd416c36eda0c3a5d32f31ff1555db2c5a3884aa8df95e8679f8203e12ee
+  sha256: b398c686960c029777afc0ed281a86f66adb956cfc3fbf6667cc6453f7b407ce
 
 build:
   skip: true  # [py<39]
@@ -22,11 +22,13 @@ requirements:
     - pip
     - python
     - setuptools >=45
-    - wheel
     - setuptools-scm >=6.0.1
     - toml
   run:
     - python
+  run_constrained:
+    - mypy >=1.10.0
+    - mypy_extensions >=0.4.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,6 @@ requirements:
     - toml
   run:
     - python
-  run_constrained:
-    # docs
-    - sphinx >=5.0
-    # check
-    - mypy >=1.10.0
-    - mypy_extensions >=0.4.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
   license_family: LGPL
   license_file: COPYING
   dev_url: https://github.com/miurahr/inflate64/
-  doc_url: https://inflate64.readthedocs.io/en/latest
+  doc_url: https://inflate64.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
inflate64 1.0.4 

**Destination channel:** Defaults

### Links

- [PKG-16515]
- dev_url:        https://github.com/miurahr/inflate64//tree/v1.0.4
- conda_forge:    https://github.com/conda-forge/inflate64-feedstock
- pypi:           https://pypi.org/project/inflate64/1.0.4
- pypi inspector: https://inspector.pypi.io/project/inflate64/1.0.4

### Explanation of changes:

- new version number


[PKG-16515]: https://anaconda.atlassian.net/browse/PKG-16515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ